### PR TITLE
Make random provider configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Some settings that you can set:
   `null` is actually the value. for example, given `data class MyClass(val id : Int?)`, if `config.useNull = true`
   then instance will look like `MyClass( id = null)`. If `config.useNull = false` then nullable parameters will have non
   null values i.e. `MyClass ( id = 123)`. Default value of default config is `InstantiatorConfig.useNull = true`
+- `InstantiatorConfig.random`: By setting it to a seeded `Random` you can recreate objects between tests and environments.
+  For example by setting it to `Random(0)`
 
 In case a constructor parameter is both, nullable and has a default value, then the default config uses the
 default value for the parameter. Example:
@@ -146,7 +148,7 @@ you want to override how primitive types are instantiated.
 ```kotlin
 class MyIntInstanceFactory : InstantiatorConfig.InstanceFactory<Int> {
     override val type: KType = Int::class.createType()
-    override fun createInstance(): Int = 42
+    override fun createInstance(random: Random): Int = 42
 }
 
 val config = InstantiatorConfig(MyIntInstanceFactory())

--- a/src/main/kotlin/com/hannesdorfmann/instantiator/Instantiator.kt
+++ b/src/main/kotlin/com/hannesdorfmann/instantiator/Instantiator.kt
@@ -111,7 +111,7 @@ class Instantiator(private val config: InstantiatorConfig) {
     private fun <T : Any> fromInstanceFactoryIfAvailbaleOtherwise(type: KType, alternative: () -> T): T {
         val factory: InstantiatorConfig.InstanceFactory<T>? =
             config.instanceFactory[type] as InstantiatorConfig.InstanceFactory<T>?
-        val instance = factory?.createInstance() ?: alternative()
+        val instance = factory?.createInstance(config.random) ?: alternative()
         return instance
     }
 

--- a/src/main/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfig.kt
+++ b/src/main/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfig.kt
@@ -7,43 +7,43 @@ import kotlin.reflect.full.createType
 
 private object IntInstanceFactory : InstantiatorConfig.InstanceFactory<Int> {
     override val type: KType = Int::class.createType()
-    override fun createInstance(): Int = Random.nextInt()
+    override fun createInstance(random: Random): Int = random.nextInt()
 }
 
 private object BooleanInstanceFactory : InstantiatorConfig.InstanceFactory<Boolean> {
     override val type: KType = Boolean::class.createType()
-    override fun createInstance(): Boolean = Random.nextBoolean()
+    override fun createInstance(random: Random): Boolean = random.nextBoolean()
 }
 
 private object FloatInstanceFactory : InstantiatorConfig.InstanceFactory<Float> {
     override val type: KType = Float::class.createType()
-    override fun createInstance(): Float = Random.nextFloat()
+    override fun createInstance(random: Random): Float = random.nextFloat()
 }
 
 private object DoubleInstanceFactory : InstantiatorConfig.InstanceFactory<Double> {
     override val type: KType = Double::class.createType()
-    override fun createInstance(): Double = Random.nextDouble()
+    override fun createInstance(random: Random): Double = random.nextDouble()
 }
 
 private object LongInstanceFactory : InstantiatorConfig.InstanceFactory<Long> {
     override val type: KType = Long::class.createType()
-    override fun createInstance(): Long = Random.nextLong()
+    override fun createInstance(random: Random): Long = random.nextLong()
 }
 
 private object ShortInstanceFactory : InstantiatorConfig.InstanceFactory<Short> {
     override val type: KType = Short::class.createType()
-    override fun createInstance(): Short = Random.nextInt(Short.MAX_VALUE.toInt()).toShort()
+    override fun createInstance(random: Random): Short = random.nextInt(Short.MAX_VALUE.toInt()).toShort()
 }
 
 private object ByteInstanceFactory : InstantiatorConfig.InstanceFactory<Byte> {
     override val type: KType = Byte::class.createType()
-    override fun createInstance(): Byte = Random.nextBytes(1)[0]
+    override fun createInstance(random: Random): Byte = random.nextBytes(1)[0]
 }
 
 private object StringInstanceFactory : InstantiatorConfig.InstanceFactory<String> {
     override val type: KType = String::class.createType()
-    override fun createInstance(): String {
-        val bytes = Random.nextBytes(10)
+    override fun createInstance(random: Random): String {
+        val bytes = random.nextBytes(10)
         return (bytes.indices)
             .map { i ->
                 charPool[(bytes[i] and 0xFF.toByte() and (charPool.size - 1).toByte()).toInt()]
@@ -53,48 +53,48 @@ private object StringInstanceFactory : InstantiatorConfig.InstanceFactory<String
 
 private object CharInstanceFactory : InstantiatorConfig.InstanceFactory<Char> {
     override val type: KType = Char::class.createType()
-    override fun createInstance(): Char = charPool[Random.nextInt(charPool.size)]
+    override fun createInstance(random: Random): Char = charPool[random.nextInt(charPool.size)]
 }
 
 private object IntNullInstanceFactory : InstantiatorConfig.InstanceFactory<Int> {
     override val type: KType = Int::class.createType(nullable = true)
-    override fun createInstance(): Int = Random.nextInt()
+    override fun createInstance(random: Random): Int = random.nextInt()
 }
 
 private object BooleanNullInstanceFactory : InstantiatorConfig.InstanceFactory<Boolean> {
     override val type: KType = Boolean::class.createType(nullable = true)
-    override fun createInstance(): Boolean = Random.nextBoolean()
+    override fun createInstance(random: Random): Boolean = random.nextBoolean()
 }
 
 private object FloatNullInstanceFactory : InstantiatorConfig.InstanceFactory<Float> {
     override val type: KType = Float::class.createType(nullable = true)
-    override fun createInstance(): Float = Random.nextFloat()
+    override fun createInstance(random: Random): Float = random.nextFloat()
 }
 
 private object DoubleNullInstanceFactory : InstantiatorConfig.InstanceFactory<Double> {
     override val type: KType = Double::class.createType(nullable = true)
-    override fun createInstance(): Double = Random.nextDouble()
+    override fun createInstance(random: Random): Double = random.nextDouble()
 }
 
 private object LongNullInstanceFactory : InstantiatorConfig.InstanceFactory<Long> {
     override val type: KType = Long::class.createType(nullable = true)
-    override fun createInstance(): Long = Random.nextLong()
+    override fun createInstance(random: Random): Long = random.nextLong()
 }
 
 private object ShortNullInstanceFactory : InstantiatorConfig.InstanceFactory<Short> {
     override val type: KType = Short::class.createType(nullable = true)
-    override fun createInstance(): Short = Random.nextInt(Short.MAX_VALUE.toInt()).toShort()
+    override fun createInstance(random: Random): Short = random.nextInt(Short.MAX_VALUE.toInt()).toShort()
 }
 
 private object ByteNullInstanceFactory : InstantiatorConfig.InstanceFactory<Byte> {
     override val type: KType = Byte::class.createType(nullable = true)
-    override fun createInstance(): Byte = Random.nextBytes(1)[0]
+    override fun createInstance(random: Random): Byte = random.nextBytes(1)[0]
 }
 
 private object StringNullInstanceFactory : InstantiatorConfig.InstanceFactory<String> {
     override val type: KType = String::class.createType(nullable = true)
-    override fun createInstance(): String {
-        val bytes = Random.nextBytes(10)
+    override fun createInstance(random: Random): String {
+        val bytes = random.nextBytes(10)
         return (bytes.indices)
             .map { i ->
                 charPool[(bytes[i] and 0xFF.toByte() and (charPool.size - 1).toByte()).toInt()]
@@ -104,7 +104,7 @@ private object StringNullInstanceFactory : InstantiatorConfig.InstanceFactory<St
 
 private object CharNullInstanceFactory : InstantiatorConfig.InstanceFactory<Char> {
     override val type: KType = Char::class.createType(nullable = true)
-    override fun createInstance(): Char = charPool[Random.nextInt(charPool.size)]
+    override fun createInstance(random: Random): Char = charPool[random.nextInt(charPool.size)]
 }
 
 private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
@@ -113,6 +113,7 @@ private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
 class InstantiatorConfig(
     val useDefaultArguments: Boolean = true,
     val useNull: Boolean = true,
+    val random: Random = Random,
     vararg factories: InstanceFactory<out Any> = DEFAULT_INSTANCE_FACTORIES
 ) {
 
@@ -154,7 +155,7 @@ class InstantiatorConfig(
 
     interface InstanceFactory<T : Any> {
         val type: KType
-        fun createInstance(): T
+        fun createInstance(random: Random): T
     }
 }
 

--- a/src/test/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfigTest.kt
+++ b/src/test/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfigTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
@@ -48,7 +49,7 @@ class InstantiatorConfigTest {
         val customString = "String was produced by custom InstanceFactory"
         val customStringInstanceFactory = object : InstantiatorConfig.InstanceFactory<String> {
             override val type: KType = String::class.createType()
-            override fun createInstance(): String = customString
+            override fun createInstance(random: Random): String = customString
         }
 
         val config1 = InstantiatorConfig(useNull = false, useDefaultArguments = false)
@@ -66,7 +67,7 @@ class InstantiatorConfigTest {
         val interfaceInstance = object : TestInterface {}
         val customStringInstanceFactory = object : InstantiatorConfig.InstanceFactory<TestInterface> {
             override val type: KType = TestInterface::class.createType()
-            override fun createInstance(): TestInterface = interfaceInstance
+            override fun createInstance(random: Random): TestInterface = interfaceInstance
         }
 
         val config1 = InstantiatorConfig(useNull = false, useDefaultArguments = false)
@@ -81,6 +82,17 @@ class InstantiatorConfigTest {
         assertEquals(config1.useNull, config2.useNull)
         assertEquals(config1.useDefaultArguments, config2.useDefaultArguments)
         assertEquals(config1.instanceFactory.size + 1, config2.instanceFactory.size)
+    }
+
+    @Test
+    internal fun `setting random creates a stable object`() {
+        val config1 = InstantiatorConfig(useNull = false, random = Random(0))
+        val config2 = InstantiatorConfig(useNull = false, random = Random(0))
+
+        val instance1 = instance<ClassWithAllOptionals>(config1)
+        val instance2 = instance<ClassWithAllOptionals>(config2)
+
+        assertEquals(instance1, instance2)
     }
 
     data class ClassWithAllOptionals(


### PR DESCRIPTION
# What was added?

- Made random provider configurable, e.g `InstantiatorConfig(random = Random(0))`
  The reasoning behind this PR is that a use case for this library would be something akin to snapshot-testing.
  ```kotlin
  @Test
  fun `test mapper of large object`() {
    val value = instance<SomeLargeObject>(InstantiatorConfig(random = Random(0))
    
    val mappedValue = mapper(value)
    
    snapshot.assertMatches(mappedValue);
  }
  ```
  But it would require the randomness to be stable across test runs.
