### PR TITLE
Make number of items to fill configurable

### DIFF
--- a/src/main/kotlin/com/hannesdorfmann/instantiator/Instantiator.kt
+++ b/src/main/kotlin/com/hannesdorfmann/instantiator/Instantiator.kt
@@ -32,15 +32,15 @@ private val wildcardTripleNullType =
 class Instantiator(private val config: InstantiatorConfig) {
 
     private fun fillList(genericsType: KType): List<Any?> {
-        return (1..10).map { createInstance(genericsType) as Any? }.toMutableList()
+        return (1..config.numberOfItemsToFull).map { createInstance(genericsType) as Any? }.toMutableList()
     }
 
     private fun fillSet(genericsType: KType): Set<Any?> {
-        return (1..10).map { createInstance(genericsType) as Any? }.toMutableSet()
+        return (1..config.numberOfItemsToFull).map { createInstance(genericsType) as Any? }.toMutableSet()
     }
 
     private fun fillMap(keyGenericsType: KType, valueGenericsType: KType): Map<Any?, Any?> {
-        return (1..10).associate { createInstance(keyGenericsType) as Any? to createInstance(valueGenericsType) as Any? }
+        return (1..config.numberOfItemsToFull).associate { createInstance(keyGenericsType) as Any? to createInstance(valueGenericsType) as Any? }
             .toMutableMap()
     }
 

--- a/src/main/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfig.kt
+++ b/src/main/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfig.kt
@@ -157,6 +157,7 @@ class InstantiatorConfig(
     val useDefaultArguments: Boolean = true,
     val useNull: Boolean = true,
     val random: Random = Random,
+    val numberOfItemsToFull: Int = 10,
     vararg factories: InstanceFactory = DEFAULT_INSTANCE_FACTORIES
 ) {
 

--- a/src/test/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfigTest.kt
+++ b/src/test/kotlin/com/hannesdorfmann/instantiator/InstantiatorConfigTest.kt
@@ -91,6 +91,30 @@ class InstantiatorConfigTest {
     }
 
     @Test
+    internal fun `setting numberOfItemsToFill fills that many`() {
+        val numberOfItemsToFill = 2
+        val config = InstantiatorConfig(useNull = false, numberOfItemsToFull = numberOfItemsToFill)
+
+        val instance = instance<ClassWithListSetMap>(config)
+
+        assertEquals(numberOfItemsToFill, instance.list.size)
+        assertEquals(numberOfItemsToFill, instance.map.size)
+        assertEquals(numberOfItemsToFill, instance.set.size)
+    }
+
+    @Test
+    internal fun `numberOfItemsToFill default fills ten`() {
+        val numberOfItemsToFill = 10
+        val config = InstantiatorConfig(useNull = false)
+
+        val instance = instance<ClassWithListSetMap>(config)
+
+        assertEquals(numberOfItemsToFill, instance.list.size)
+        assertEquals(numberOfItemsToFill, instance.map.size)
+        assertEquals(numberOfItemsToFill, instance.set.size)
+    }
+
+    @Test
     fun `toNullableInstanceFactory() with mode=ALWAYS_NULL return always null`() {
         val nullableIntFactory = IntFactory().toNullableInstanceFactory(
             mode = ToNullableInstanceFactoryMode.ALWAYS_NULL
@@ -176,6 +200,8 @@ class InstantiatorConfigTest {
     )
 
     data class ClassWithDefaults(val i: Int, val s: String = "someString")
+
+    data class ClassWithListSetMap(val list : List<Int>, val set: Set<Int>, val map: Map<Int, Int>)
 
     interface TestInterface {}
 }


### PR DESCRIPTION
## What was added?
Made  number of items to fill configurable, e.g `InstantiatorConfig(numberOfItemsToFull = 3)`

## Why?
Being able to configure this value gives flexibility to instantiate models more specific to different use cases.

Also, in our cases we use this library to instantiate generated network models written by our API team. These models sometimes have multiple layers of nested lists and are taking up too much memory in our unit test environment.